### PR TITLE
increases the max. NDEF message size transmitable from 256Bytes to 32kB.

### DIFF
--- a/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
+++ b/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
@@ -54,7 +54,6 @@ class KHostApduService : HostApduService() {
     // for ReadBinary would trigger and we don't want that in succession
     private var READ_CAPABILITY_CONTAINER_CHECK = false
 
-    //수정 부분
     private val READ_CAPABILITY_CONTAINER_RESPONSE = byteArrayOf(
         0x00.toByte(), 0x0F.toByte(), // CCLEN length of the CC file
         0x20.toByte(), // Mapping Version 2.0
@@ -63,7 +62,7 @@ class KHostApduService : HostApduService() {
         0x04.toByte(), // T field of the NDEF File Control TLV
         0x06.toByte(), // L field of the NDEF File Control TLV
         0xE1.toByte(), 0x04.toByte(), // File Identifier of NDEF file
-        0x00.toByte(), 0xFF.toByte(), // Maximum NDEF file size of 65534 bytes
+        0x7F.toByte(), 0xFF.toByte(), // Maximum NDEF file size of 32767 bytes
         0x00.toByte(), // Read access without any security
         0xFF.toByte(), // Write access without any security
         0x90.toByte(), 0x00.toByte(), // A_OKAY
@@ -349,7 +348,7 @@ class KHostApduService : HostApduService() {
 
     //2023.09.16 modify
     companion object {
-        private val READ_BLOCK_SIZE: Int = 100
+        private val READ_BLOCK_SIZE: Int = 32767
         @SuppressLint("LongLogTag")
         @JvmStatic
         fun readNdefMessageFromFile(context: Context): String? {

--- a/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
+++ b/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
@@ -168,6 +168,14 @@ class KHostApduService : HostApduService() {
         Log.i(TAG, "processCommandApdu() | incoming commandApdu: " + commandApdu.toHex())
 
         //
+        // Command APDU of less than 5 bytes
+        //
+        if (commandApdu.size < 5) {
+            Log.i(TAG, "Received incomplete command APDU. Our Response: " + A_ERROR.toHex());
+            return A_ERROR;
+        }
+
+        //
         // First command: NDEF Tag Application select (Section 5.5.2 in NFC Forum spec)
         //
         if (APDU_SELECT.contentEquals(commandApdu)) {

--- a/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
+++ b/android/src/main/kotlin/com/novice/flutter_nfc_hce/KHostApduService.kt
@@ -180,6 +180,7 @@ class KHostApduService : HostApduService() {
         //
         if (APDU_SELECT.contentEquals(commandApdu)) {
             Log.i(TAG, "APDU_SELECT triggered. Our Response: " + A_OKAY.toHex())
+            READ_CAPABILITY_CONTAINER_CHECK = false
             return A_OKAY
         }
 
@@ -200,7 +201,6 @@ class KHostApduService : HostApduService() {
                 TAG,
                 "READ_CAPABILITY_CONTAINER triggered. Our Response: " + READ_CAPABILITY_CONTAINER_RESPONSE.toHex(),
             )
-            READ_CAPABILITY_CONTAINER_CHECK = true
             return READ_CAPABILITY_CONTAINER_RESPONSE
         }
 
@@ -209,6 +209,7 @@ class KHostApduService : HostApduService() {
         //
         if (NDEF_SELECT_OK.contentEquals(commandApdu)) {
             Log.i(TAG, "NDEF_SELECT_OK triggered. Our Response: " + A_OKAY.toHex())
+            READ_CAPABILITY_CONTAINER_CHECK = true
             return A_OKAY
         }
 
@@ -220,7 +221,6 @@ class KHostApduService : HostApduService() {
 
             Log.i(TAG, "NDEF_READ_BINARY_NLEN triggered. Our Response: " + response.toHex())
 
-            READ_CAPABILITY_CONTAINER_CHECK = false
             return response
         }
 
@@ -252,7 +252,6 @@ class KHostApduService : HostApduService() {
 
             Log.i(TAG, "NDEF_READ_BINARY triggered. Our Response: " + response.toHex())
 
-            READ_CAPABILITY_CONTAINER_CHECK = false
             return response
         }
 


### PR DESCRIPTION
This increases the max. NDEF message size transmitable from 256Bytes to 32kB.

The original proof-of-concept implementation initially used 64kB violating the NFC Type 4 NDEF 2.0 specification. Newer Android versions follow the specification more strictly. As a result, the capability container record was rejected and the read aborted. The 32kB are the max. permitted by the specification, and is accepted by all Android versions to my knowledge. An increare beyond that limit is possible, but required implementing NDEF 3.0.

Moreover the READ_CAPABILITY_CONTAINER_CHECK now is switched in processing SELECT command APDUs, because the larger message size requires reading in chunks, where the original code reset the flag too early.

Also, a command APDU size check was added to processCommandApdu. This is to protect against an incorrectly implemented tag reader app I encountered in the field. It sent a single final byte upon completion of the read, which caused the commandApdu.sliceArray(0..1) below to error out. The exception escaping from processCommandApdu is rather bad as there are Android versions where this causes NFC HCE malfunction until the device is rebooted.

[REL-2876]